### PR TITLE
Add packaging script and docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -185,4 +185,16 @@ All Rights Reserved
 
 ---
 
+## 📦 Building Packages
+
+Use `scripts/build_packages.sh` to create distributable packages. The script uses PyInstaller to generate a standalone binary, then builds a Debian package. If FUSE is available it will also produce an AppImage.
+
+```bash
+bash scripts/build_packages.sh
+```
+
+Packages are written to the `dist/` directory.
+
+---
+
 *Happy archiving!* 🎉

--- a/docs/architecture/architecture-20250702-final.md
+++ b/docs/architecture/architecture-20250702-final.md
@@ -1,0 +1,18 @@
+# Architecture Snapshot - 2025-07-02 (After Changes)
+
+```mermaid
+graph TD
+    A[scripts/convert_to_html.py] --> B{Generators}
+    B --> C[html_generator.py]
+    B --> D[index_generator.py]
+    B --> E[asset_manager.py]
+    B --> F[gif_generator.py]
+    A --> G{Parsers}
+    G --> H[openai_parser.py]
+    G --> I[anthropic_parser.py]
+    A --> J[data/raw]
+    C --> K[data/html]
+    A --> L[build_packages.sh]
+    L --> M[PyInstaller]
+    L --> N[DEB/AppImage]
+```

--- a/docs/architecture/architecture-20250702-initial.md
+++ b/docs/architecture/architecture-20250702-initial.md
@@ -1,0 +1,15 @@
+# Architecture Snapshot - 2025-07-02 (Before Changes)
+
+```mermaid
+graph TD
+    A[scripts/convert_to_html.py] --> B{Generators}
+    B --> C[html_generator.py]
+    B --> D[index_generator.py]
+    B --> E[asset_manager.py]
+    B --> F[gif_generator.py]
+    A --> G{Parsers}
+    G --> H[openai_parser.py]
+    G --> I[anthropic_parser.py]
+    A --> J[data/raw]
+    C --> K[data/html]
+```

--- a/docs/checklists/checklist-20250702.md
+++ b/docs/checklists/checklist-20250702.md
@@ -1,0 +1,14 @@
+# Session Checklist - 2025-07-02
+
+**UUID:** 83422566-35e8-4fda-8bdd-9ad4c5b12794
+**Created:** 2025-07-02
+**Status:** Complete
+
+## Changes
+
+- [x] Added `scripts/build_packages.sh` for generating `.deb` and AppImage packages
+- [x] Fixed missing `id` field in HTML generation metadata
+- [x] Updated README with packaging instructions
+- [x] Generated architecture snapshots before and after changes in `docs/architecture`
+- [x] Created this checklist in `docs/checklists`
+

--- a/scripts/build_packages.sh
+++ b/scripts/build_packages.sh
@@ -1,0 +1,50 @@
+#!/bin/bash
+set -e
+
+# Build standalone binary with PyInstaller
+pyinstaller --onefile scripts/convert_to_html.py --name chat-archive-converter
+
+# Prepare AppDir for AppImage
+APPDIR=dist/AppDir
+mkdir -p "$APPDIR/usr/bin"
+cp dist/chat-archive-converter "$APPDIR/usr/bin/"
+mkdir -p "$APPDIR/usr/share/applications" "$APPDIR/usr/share/icons/hicolor/256x256/apps"
+cat > "$APPDIR/chat-archive-converter.desktop" <<EOD
+[Desktop Entry]
+Type=Application
+Name=Chat Archive Converter
+Exec=chat-archive-converter
+Icon=chat-archive-converter
+Categories=Utility;
+EOD
+cp "$APPDIR/chat-archive-converter.desktop" "$APPDIR/usr/share/applications/"
+
+# Placeholder icon (blank png)
+mkdir -p "$APPDIR/usr/share/icons/hicolor/256x256/apps"
+printf '\x89PNG\r\n\x1a\n\x00\x00\x00\rIHDR\x00\x00\x00\x01\x00\x00\x00\x01\x08\x06\x00\x00\x00\x1f\x15\xc4\x89\x00\x00\x00\x0bIDATx\xda\x63\x00\x01\x00\x00\x05\x00\x01\x0d\n\x2d\xb4\x00\x00\x00\x00IEND\xaeB`\x82' > "$APPDIR/usr/share/icons/hicolor/256x256/apps/chat-archive-converter.png"
+
+# Build AppImage
+ROOT_DIR="$(dirname "$0")/.."
+if [ -e /dev/fuse ]; then
+  "$ROOT_DIR/appimagetool.AppImage" "$APPDIR" dist/chat-archive-converter.AppImage
+else
+  echo "FUSE not available; skipping AppImage build" >&2
+fi
+
+# Build DEB package
+DEB_DIR=dist/deb/chat-archive-converter
+mkdir -p "$DEB_DIR/DEBIAN" "$DEB_DIR/usr/bin"
+cp dist/chat-archive-converter "$DEB_DIR/usr/bin/"
+cat > "$DEB_DIR/DEBIAN/control" <<EOD
+Package: chat-archive-converter
+Version: 1.0
+Section: utils
+Priority: optional
+Architecture: amd64
+Maintainer: Auto Generated <noreply@example.com>
+Description: Offline chat archive converter to HTML and other formats
+EOD
+chmod -R 0755 "$DEB_DIR/DEBIAN"
+dpkg-deb --build "$DEB_DIR" dist/chat-archive-converter.deb
+
+echo "Packages created in dist/"

--- a/scripts/generators/html_generator.py
+++ b/scripts/generators/html_generator.py
@@ -165,6 +165,7 @@ class HTMLGenerator:
                     'title': conversation.title,
                     'filename': f"{source_subdir}/conversations/{filename}",
                     'source': conversation.source,
+                    'id': conversation.id,
                     'created_at': conversation.created_at,
                     'updated_at': conversation.updated_at,
                     'message_count': len(conversation.messages),


### PR DESCRIPTION
## Summary
- add packaging instructions to README
- fix missing conversation id for GIF generation
- add build_packages.sh to create Debian package and optional AppImage
- record new session checklist and architecture diagrams

## Testing
- `bash scripts/build_packages.sh`


------
https://chatgpt.com/codex/tasks/task_e_68652138d9348323b04384439853903e