### PR TITLE
Add incremental OpenAI delta processor

### DIFF
--- a/README.md
+++ b/README.md
@@ -142,6 +142,15 @@ Use `scripts/export_conversations.py` to convert selected chats to PDF, DOCX, Ex
 python scripts/export_conversations.py --match "search text" --formats pdf,docx,md --output exports
 ```
 
+### Incremental Processing for OpenAI
+
+Use `scripts/process_openai_delta.py` to append new conversations from a fresh OpenAI export without regenerating existing HTML.
+
+```bash
+python scripts/process_openai_delta.py --input data/raw/openai_conversations.json
+```
+
+
 
 ## 📂 Repository Structure
 

--- a/README.md
+++ b/README.md
@@ -150,6 +150,14 @@ Use `scripts/process_openai_delta.py` to append new conversations from a fresh O
 python scripts/process_openai_delta.py --input data/raw/openai_conversations.json
 ```
 
+### Incremental Processing for Anthropic
+
+Use `scripts/process_anthropic_delta.py` to append new Claude conversations without rebuilding previously generated HTML.
+
+```bash
+python scripts/process_anthropic_delta.py --input data/raw/example_claude_conversations.json
+```
+
 
 
 ## 📂 Repository Structure

--- a/docs/architecture/architecture-20250702-incremental-final.md
+++ b/docs/architecture/architecture-20250702-incremental-final.md
@@ -1,0 +1,22 @@
+# Architecture Snapshot - 2025-07-02 (After Incremental Script)
+
+```mermaid
+graph TD
+    A[scripts/convert_to_html.py] --> B{Generators}
+    B --> C[html_generator.py]
+    B --> D[index_generator.py]
+    B --> E[asset_manager.py]
+    B --> F[gif_generator.py]
+    A --> G{Parsers}
+    G --> H[openai_parser.py]
+    G --> I[anthropic_parser.py]
+    A --> J[data/raw]
+    C --> K[data/html]
+    A --> L[build_packages.sh]
+    L --> M[PyInstaller]
+    L --> N[DEB/AppImage]
+    O[scripts/process_openai_delta.py] --> H
+    O --> C
+    O --> D
+    O --> E
+```

--- a/docs/architecture/architecture-20250702-incremental-initial.md
+++ b/docs/architecture/architecture-20250702-incremental-initial.md
@@ -1,0 +1,18 @@
+# Architecture Snapshot - 2025-07-02 (Before Incremental Script)
+
+```mermaid
+graph TD
+    A[scripts/convert_to_html.py] --> B{Generators}
+    B --> C[html_generator.py]
+    B --> D[index_generator.py]
+    B --> E[asset_manager.py]
+    B --> F[gif_generator.py]
+    A --> G{Parsers}
+    G --> H[openai_parser.py]
+    G --> I[anthropic_parser.py]
+    A --> J[data/raw]
+    C --> K[data/html]
+    A --> L[build_packages.sh]
+    L --> M[PyInstaller]
+    L --> N[DEB/AppImage]
+```

--- a/docs/architecture/architecture-20250703-anthropic-final.md
+++ b/docs/architecture/architecture-20250703-anthropic-final.md
@@ -1,0 +1,26 @@
+# Architecture Snapshot - 2025-07-03 (After Anthropic Incremental Script)
+
+```mermaid
+graph TD
+    A[scripts/convert_to_html.py] --> B{Generators}
+    B --> C[html_generator.py]
+    B --> D[index_generator.py]
+    B --> E[asset_manager.py]
+    B --> F[gif_generator.py]
+    A --> G{Parsers}
+    G --> H[openai_parser.py]
+    G --> I[anthropic_parser.py]
+    A --> J[data/raw]
+    C --> K[data/html]
+    A --> L[build_packages.sh]
+    L --> M[PyInstaller]
+    L --> N[DEB/AppImage]
+    O[scripts/process_openai_delta.py] --> H
+    O --> C
+    O --> D
+    O --> E
+    P[scripts/process_anthropic_delta.py] --> I
+    P --> C
+    P --> D
+    P --> E
+```

--- a/docs/architecture/architecture-20250703-anthropic-initial.md
+++ b/docs/architecture/architecture-20250703-anthropic-initial.md
@@ -1,0 +1,22 @@
+# Architecture Snapshot - 2025-07-03 (Before Anthropic Incremental Script)
+
+```mermaid
+graph TD
+    A[scripts/convert_to_html.py] --> B{Generators}
+    B --> C[html_generator.py]
+    B --> D[index_generator.py]
+    B --> E[asset_manager.py]
+    B --> F[gif_generator.py]
+    A --> G{Parsers}
+    G --> H[openai_parser.py]
+    G --> I[anthropic_parser.py]
+    A --> J[data/raw]
+    C --> K[data/html]
+    A --> L[build_packages.sh]
+    L --> M[PyInstaller]
+    L --> N[DEB/AppImage]
+    O[scripts/process_openai_delta.py] --> H
+    O --> C
+    O --> D
+    O --> E
+```

--- a/docs/checklists/checklist-20250702-incremental.md
+++ b/docs/checklists/checklist-20250702-incremental.md
@@ -1,0 +1,10 @@
+# Session Checklist - 2025-07-02 Incremental Script
+
+**UUID:** 3e85b501-bb0e-499a-882d-cc162d0fb3c2
+**Created:** 2025-07-02
+**Status:** Complete
+
+## Changes
+- [x] Add incremental OpenAI processing script
+- [x] Generate updated architecture docs
+- [x] Update README with usage of the new script

--- a/docs/checklists/checklist-20250703-anthropic.md
+++ b/docs/checklists/checklist-20250703-anthropic.md
@@ -1,0 +1,11 @@
+# Session Checklist - 2025-07-03 Anthropic Delta
+
+**UUID:** 45a4114a-7425-4089-8c2f-a803a2120e87
+**Created:** 2025-07-03
+**Status:** Complete
+
+## Changes
+- [x] Add incremental Anthropic processing script
+- [x] Document usage of new script in README
+- [x] Generate architecture snapshots before and after changes
+- [x] Record this checklist

--- a/scripts/process_anthropic_delta.py
+++ b/scripts/process_anthropic_delta.py
@@ -1,0 +1,107 @@
+#!/usr/bin/env python3
+"""Incrementally process new Anthropic conversations without rebuilding existing output."""
+import json
+import argparse
+from pathlib import Path
+
+from parsers.anthropic_parser import AnthropicParser
+from generators.html_generator import HTMLGenerator
+from generators.index_generator import IndexGenerator
+from generators.asset_manager import AssetManager
+
+STATE_DIR = Path('data/html/incremental')
+PROCESSED_IDS_FILE = STATE_DIR / 'processed_ids.json'
+METADATA_FILE = STATE_DIR / 'metadata.json'
+TEMPLATES_DIR = Path('scripts/templates')
+ASSETS_DIR = Path('scripts/assets')
+
+
+def load_processed_ids() -> set:
+    if PROCESSED_IDS_FILE.exists():
+        with open(PROCESSED_IDS_FILE, 'r', encoding='utf-8') as f:
+            return set(json.load(f))
+    return set()
+
+
+def save_processed_ids(ids: set) -> None:
+    STATE_DIR.mkdir(parents=True, exist_ok=True)
+    with open(PROCESSED_IDS_FILE, 'w', encoding='utf-8') as f:
+        json.dump(sorted(ids), f, indent=2)
+
+
+def load_metadata() -> list:
+    if METADATA_FILE.exists():
+        with open(METADATA_FILE, 'r', encoding='utf-8') as f:
+            return json.load(f)
+    return []
+
+
+def save_metadata(metadata: list) -> None:
+    STATE_DIR.mkdir(parents=True, exist_ok=True)
+    with open(METADATA_FILE, 'w', encoding='utf-8') as f:
+        json.dump(metadata, f, indent=2, default=str)
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description="Process only new Anthropic conversations and update HTML output.")
+    parser.add_argument('--input', default='data/raw/example_claude_conversations.json', help='Path to Anthropic export file')
+    args = parser.parse_args()
+
+    anthropic_parser = AnthropicParser()
+    html_gen = HTMLGenerator(str(TEMPLATES_DIR), str(ASSETS_DIR))
+    index_gen = IndexGenerator(str(TEMPLATES_DIR))
+    asset_mgr = AssetManager(str(ASSETS_DIR))
+
+    conversations = anthropic_parser.parse_file(args.input)
+    if not conversations:
+        print('No conversations found in input file.')
+        return
+
+    processed_ids = load_processed_ids()
+    metadata = load_metadata()
+
+    new_conversations = [c for c in conversations if c.id not in processed_ids]
+    if not new_conversations:
+        print('No new conversations to process.')
+        return
+
+    conversations_dir = STATE_DIR / 'anthropic'
+    conversations_dir.mkdir(parents=True, exist_ok=True)
+
+    new_metadata = html_gen.generate_conversations_batch(
+        conversations=new_conversations,
+        output_dir=str(STATE_DIR),
+        source_subdir='anthropic',
+        assets_relative_path='../../assets',
+        index_relative_path='../../index.html',
+        source_index_relative_path='../index.html'
+    )
+
+    metadata.extend(new_metadata)
+
+    index_gen.generate_source_index(
+        conversations=metadata,
+        source_name='anthropic',
+        output_path=str(STATE_DIR / 'anthropic' / 'index.html'),
+        assets_relative_path='../assets',
+        main_index_path='../index.html'
+    )
+    index_gen.generate_main_index(
+        all_conversations=metadata,
+        output_path=str(STATE_DIR / 'index.html'),
+        assets_relative_path='assets'
+    )
+
+    assets_output_dir = STATE_DIR / 'assets'
+    if not assets_output_dir.exists():
+        asset_mgr.setup_complete_assets(str(assets_output_dir), site_name='Chat Archive')
+
+    processed_ids.update(c.id for c in new_conversations)
+    save_processed_ids(processed_ids)
+    save_metadata(metadata)
+
+    print(f'Processed {len(new_conversations)} new conversations.')
+
+
+if __name__ == '__main__':
+    main()

--- a/scripts/process_openai_delta.py
+++ b/scripts/process_openai_delta.py
@@ -1,0 +1,108 @@
+#!/usr/bin/env python3
+"""Incrementally process new OpenAI conversations without rebuilding existing output."""
+import os
+import json
+import argparse
+from pathlib import Path
+
+from parsers.openai_parser import OpenAIParser
+from generators.html_generator import HTMLGenerator
+from generators.index_generator import IndexGenerator
+from generators.asset_manager import AssetManager
+
+STATE_DIR = Path('data/html/incremental')
+PROCESSED_IDS_FILE = STATE_DIR / 'processed_ids.json'
+METADATA_FILE = STATE_DIR / 'metadata.json'
+TEMPLATES_DIR = Path('scripts/templates')
+ASSETS_DIR = Path('scripts/assets')
+
+
+def load_processed_ids() -> set:
+    if PROCESSED_IDS_FILE.exists():
+        with open(PROCESSED_IDS_FILE, 'r', encoding='utf-8') as f:
+            return set(json.load(f))
+    return set()
+
+
+def save_processed_ids(ids: set) -> None:
+    STATE_DIR.mkdir(parents=True, exist_ok=True)
+    with open(PROCESSED_IDS_FILE, 'w', encoding='utf-8') as f:
+        json.dump(sorted(ids), f, indent=2)
+
+
+def load_metadata() -> list:
+    if METADATA_FILE.exists():
+        with open(METADATA_FILE, 'r', encoding='utf-8') as f:
+            return json.load(f)
+    return []
+
+
+def save_metadata(metadata: list) -> None:
+    STATE_DIR.mkdir(parents=True, exist_ok=True)
+    with open(METADATA_FILE, 'w', encoding='utf-8') as f:
+        json.dump(metadata, f, indent=2, default=str)
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description="Process only new OpenAI conversations and update HTML output.")
+    parser.add_argument('--input', default='data/raw/openai_conversations.json', help='Path to OpenAI export file')
+    args = parser.parse_args()
+
+    openai_parser = OpenAIParser()
+    html_gen = HTMLGenerator(str(TEMPLATES_DIR), str(ASSETS_DIR))
+    index_gen = IndexGenerator(str(TEMPLATES_DIR))
+    asset_mgr = AssetManager(str(ASSETS_DIR))
+
+    conversations = openai_parser.parse_file(args.input)
+    if not conversations:
+        print('No conversations found in input file.')
+        return
+
+    processed_ids = load_processed_ids()
+    metadata = load_metadata()
+
+    new_conversations = [c for c in conversations if c.id not in processed_ids]
+    if not new_conversations:
+        print('No new conversations to process.')
+        return
+
+    conversations_dir = STATE_DIR / 'openai'
+    conversations_dir.mkdir(parents=True, exist_ok=True)
+
+    new_metadata = html_gen.generate_conversations_batch(
+        conversations=new_conversations,
+        output_dir=str(STATE_DIR),
+        source_subdir='openai',
+        assets_relative_path='../../assets',
+        index_relative_path='../../index.html',
+        source_index_relative_path='../index.html'
+    )
+
+    metadata.extend(new_metadata)
+
+    index_gen.generate_source_index(
+        conversations=metadata,
+        source_name='openai',
+        output_path=str(STATE_DIR / 'openai' / 'index.html'),
+        assets_relative_path='../assets',
+        main_index_path='../index.html'
+    )
+    index_gen.generate_main_index(
+        all_conversations=metadata,
+        output_path=str(STATE_DIR / 'index.html'),
+        assets_relative_path='assets'
+    )
+
+    assets_output_dir = STATE_DIR / 'assets'
+    if not assets_output_dir.exists():
+        asset_mgr.setup_complete_assets(str(assets_output_dir), site_name='Chat Archive')
+
+    processed_ids.update(c.id for c in new_conversations)
+    save_processed_ids(processed_ids)
+    save_metadata(metadata)
+
+    print(f'Processed {len(new_conversations)} new conversations.')
+
+
+if __name__ == '__main__':
+    main()


### PR DESCRIPTION
## Summary
- add script to process only new OpenAI conversations
- document incremental script usage in README
- record new architecture snapshots
- add session checklist

## Testing
- `python3 -m py_compile scripts/process_openai_delta.py`
- `pip install -r requirements.txt`
- `python3 scripts/process_openai_delta.py --input data/raw/example_openai_conversations.json`

------
https://chatgpt.com/codex/tasks/task_e_686525d0bc8083238aa824723868bb3e