### PR TITLE
Add Python-based LLM extraction

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -46,3 +46,6 @@ Thumbs.db
 *.swp
 *.swo
 *~
+# Node
+node_modules/
+dist/

--- a/bin/chat-reader.js
+++ b/bin/chat-reader.js
@@ -1,0 +1,22 @@
+#!/usr/bin/env node
+import { Command } from 'commander';
+import { generate } from '../src/generator';
+
+const program = new Command();
+program
+  .requiredOption('-i, --input <file>', 'Path to conversations.json')
+  .option('--import-hkg', 'Import conversation data into hKG')
+  .option('--llm-model <model>', 'LLM model to use');
+
+program.parse(process.argv);
+
+const opts = program.opts();
+
+generate({
+  inputPath: opts.input,
+  importHkg: opts.importHkg,
+  llmModel: opts.llmModel
+}).catch(err => {
+  console.error(err);
+  process.exit(1);
+});

--- a/docs/architecture/architecture-20250707-hkg-final.md
+++ b/docs/architecture/architecture-20250707-hkg-final.md
@@ -1,0 +1,20 @@
+# Architecture Snapshot - 2025-07-07 (After Import to hKG)
+
+```mermaid
+graph TD
+    A[src/main.js] --> B(MainWindow)
+    B --> C(HeaderBar)
+    B --> D(ConfigView)
+    B --> E(LogView)
+    D --> F(SettingsModel)
+    D --> G(FileManager)
+    D --> H(ProcessManager)
+    H --> I(LogView)
+    H --> J(NotificationManager)
+    K[scripts/build_packages.sh] --> L(chat-archive-converter.deb)
+    L --> M[Desktop Entry]
+    N[bin/chat-reader.js] --> O(generator.ts)
+    O --> P(deepseekClient.ts)
+    O --> Q(hkgImporter.ts)
+    Q --> R((Neo4j))
+```

--- a/docs/architecture/architecture-20250707-hkg-initial.md
+++ b/docs/architecture/architecture-20250707-hkg-initial.md
@@ -1,0 +1,16 @@
+# Architecture Snapshot - 2025-07-07 (Before Import to hKG)
+
+```mermaid
+graph TD
+    A[src/main.js] --> B(MainWindow)
+    B --> C(HeaderBar)
+    B --> D(ConfigView)
+    B --> E(LogView)
+    D --> F(SettingsModel)
+    D --> G(FileManager)
+    D --> H(ProcessManager)
+    H --> I(LogView)
+    H --> J(NotificationManager)
+    K[scripts/build_packages.sh] --> L(chat-archive-converter.deb)
+    L --> M[Desktop Entry]
+```

--- a/docs/architecture/architecture-20250708-llm-final.md
+++ b/docs/architecture/architecture-20250708-llm-final.md
@@ -1,0 +1,23 @@
+# Architecture Snapshot - 2025-07-08 (After LLM integration improvements)
+
+```mermaid
+graph TD
+    A[src/main.js] --> B(MainWindow)
+    B --> C(HeaderBar)
+    B --> D(ConfigView)
+    B --> E(LogView)
+    D --> F(SettingsModel)
+    D --> G(FileManager)
+    D --> H(ProcessManager)
+    H --> I(LogView)
+    H --> J(NotificationManager)
+    K[scripts/build_packages.sh] --> L(chat-archive-converter.deb)
+    L --> M[Desktop Entry]
+    N[bin/chat-reader.js] --> O(generator.ts)
+    O --> P(deepseekClient.ts)
+    P --> X[scripts/extract_concepts.py]
+    O --> Q(hkgImporter.ts)
+    Q --> R((Neo4j))
+    Q --> S[hkg-delta.json]
+    S ..> T((Qdrant))
+```

--- a/docs/architecture/architecture-20250708-llm-initial.md
+++ b/docs/architecture/architecture-20250708-llm-initial.md
@@ -1,0 +1,20 @@
+# Architecture Snapshot - 2025-07-08 (Before LLM integration improvements)
+
+```mermaid
+graph TD
+    A[src/main.js] --> B(MainWindow)
+    B --> C(HeaderBar)
+    B --> D(ConfigView)
+    B --> E(LogView)
+    D --> F(SettingsModel)
+    D --> G(FileManager)
+    D --> H(ProcessManager)
+    H --> I(LogView)
+    H --> J(NotificationManager)
+    K[scripts/build_packages.sh] --> L(chat-archive-converter.deb)
+    L --> M[Desktop Entry]
+    N[bin/chat-reader.js] --> O(generator.ts)
+    O --> P(deepseekClient.ts)
+    O --> Q(hkgImporter.ts)
+    Q --> R((Neo4j))
+```

--- a/docs/checklists/checklist-20250707-hkg.md
+++ b/docs/checklists/checklist-20250707-hkg.md
@@ -1,0 +1,15 @@
+# Session Checklist - 2025-07-07 Import to hKG
+
+**UUID:** 6c9e44b9-45a1-4d89-bf38-d6a7be0352b2
+**Created:** 2025-07-07
+**Status:** Complete
+
+## Changes
+- [x] Capture architecture snapshot before changes
+- [x] Add Node-based generator and hKG importer scaffolding
+- [x] Add deepseek LLM client placeholder
+- [x] Implement CLI option `--import-hkg`
+- [x] Create React toolbar toggle stub
+- [x] Update package.json with Neo4j and build tooling
+- [x] Write architecture snapshot after changes
+- [x] Record final checklist

--- a/docs/checklists/checklist-20250708-llm.md
+++ b/docs/checklists/checklist-20250708-llm.md
@@ -1,0 +1,13 @@
+# Session Checklist - 2025-07-08 LLM Integration Updates
+
+**UUID:** d6c3fb26-b56f-44dc-8076-bc9bf5ea4dca
+**Created:** 2025-07-08
+**Status:** Complete
+
+## Changes
+- [x] Capture architecture snapshot before changes
+- [x] Replace DeepSeek placeholder with Python-based LLM call
+- [x] Wire generator to use new Python script
+- [x] Ensure Neo4j importer writes delta and updates Meta node
+- [x] Add architecture snapshot after changes
+- [x] Record final checklist

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,0 +1,444 @@
+{
+  "name": "ai-chat-reader",
+  "version": "1.0.0",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {
+    "": {
+      "name": "ai-chat-reader",
+      "version": "1.0.0",
+      "dependencies": {
+        "commander": "^11.0.0",
+        "neo4j-driver": "^5.19.0"
+      },
+      "devDependencies": {
+        "@types/node": "^20.9.0",
+        "@types/react": "^18.2.0",
+        "react": "^18.2.0",
+        "ts-node": "^10.9.0",
+        "typescript": "^5.4.0"
+      }
+    },
+    "node_modules/@cspotcode/source-map-support": {
+      "version": "0.8.1",
+      "resolved": "https://registry.npmjs.org/@cspotcode/source-map-support/-/source-map-support-0.8.1.tgz",
+      "integrity": "sha512-IchNf6dN4tHoMFIn/7OE8LWZ19Y6q/67Bmf6vnGREv8RSbBVb9LPJxEcnwrcwX6ixSvaiGoomAUvu4YSxXrVgw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jridgewell/trace-mapping": "0.3.9"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@jridgewell/resolve-uri": {
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/@jridgewell/resolve-uri/-/resolve-uri-3.1.2.tgz",
+      "integrity": "sha512-bRISgCIjP20/tbWSPWMEi54QVPRZExkuD9lJL+UIxUKtwVJA8wW1Trb1jMs1RFXo1CBTNZ/5hpC9QvmKWdopKw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.0.0"
+      }
+    },
+    "node_modules/@jridgewell/sourcemap-codec": {
+      "version": "1.5.4",
+      "resolved": "https://registry.npmjs.org/@jridgewell/sourcemap-codec/-/sourcemap-codec-1.5.4.tgz",
+      "integrity": "sha512-VT2+G1VQs/9oz078bLrYbecdZKs912zQlkelYpuf+SXF+QvZDYJlbx/LSx+meSAwdDFnF8FVXW92AVjjkVmgFw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@jridgewell/trace-mapping": {
+      "version": "0.3.9",
+      "resolved": "https://registry.npmjs.org/@jridgewell/trace-mapping/-/trace-mapping-0.3.9.tgz",
+      "integrity": "sha512-3Belt6tdc8bPgAtbcmdtNJlirVoTmEb5e2gC94PnkwEW9jI6CAHUeoG85tjWP5WquqfavoMtMwiG4P926ZKKuQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jridgewell/resolve-uri": "^3.0.3",
+        "@jridgewell/sourcemap-codec": "^1.4.10"
+      }
+    },
+    "node_modules/@tsconfig/node10": {
+      "version": "1.0.11",
+      "resolved": "https://registry.npmjs.org/@tsconfig/node10/-/node10-1.0.11.tgz",
+      "integrity": "sha512-DcRjDCujK/kCk/cUe8Xz8ZSpm8mS3mNNpta+jGCA6USEDfktlNvm1+IuZ9eTcDbNk41BHwpHHeW+N1lKCz4zOw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@tsconfig/node12": {
+      "version": "1.0.11",
+      "resolved": "https://registry.npmjs.org/@tsconfig/node12/-/node12-1.0.11.tgz",
+      "integrity": "sha512-cqefuRsh12pWyGsIoBKJA9luFu3mRxCA+ORZvA4ktLSzIuCUtWVxGIuXigEwO5/ywWFMZ2QEGKWvkZG1zDMTag==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@tsconfig/node14": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/@tsconfig/node14/-/node14-1.0.3.tgz",
+      "integrity": "sha512-ysT8mhdixWK6Hw3i1V2AeRqZ5WfXg1G43mqoYlM2nc6388Fq5jcXyr5mRsqViLx/GJYdoL0bfXD8nmF+Zn/Iow==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@tsconfig/node16": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/@tsconfig/node16/-/node16-1.0.4.tgz",
+      "integrity": "sha512-vxhUy4J8lyeyinH7Azl1pdd43GJhZH/tP2weN8TntQblOY+A0XbT8DJk1/oCPuOOyg/Ja757rG0CgHcWC8OfMA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@types/node": {
+      "version": "20.19.4",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-20.19.4.tgz",
+      "integrity": "sha512-OP+We5WV8Xnbuvw0zC2m4qfB/BJvjyCwtNjhHdJxV1639SGSKrLmJkc3fMnp2Qy8nJyHp8RO6umxELN/dS1/EA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "undici-types": "~6.21.0"
+      }
+    },
+    "node_modules/@types/prop-types": {
+      "version": "15.7.15",
+      "resolved": "https://registry.npmjs.org/@types/prop-types/-/prop-types-15.7.15.tgz",
+      "integrity": "sha512-F6bEyamV9jKGAFBEmlQnesRPGOQqS2+Uwi0Em15xenOxHaf2hv6L8YCVn3rPdPJOiJfPiCnLIRyvwVaqMY3MIw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@types/react": {
+      "version": "18.3.23",
+      "resolved": "https://registry.npmjs.org/@types/react/-/react-18.3.23.tgz",
+      "integrity": "sha512-/LDXMQh55EzZQ0uVAZmKKhfENivEvWz6E+EYzh+/MCjMhNsotd+ZHhBGIjFDTi6+fz0OhQQQLbTgdQIxxCsC0w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/prop-types": "*",
+        "csstype": "^3.0.2"
+      }
+    },
+    "node_modules/acorn": {
+      "version": "8.15.0",
+      "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.15.0.tgz",
+      "integrity": "sha512-NZyJarBfL7nWwIq+FDL6Zp/yHEhePMNnnJ0y3qfieCrmNvYct8uvtiV41UvlSe6apAfk0fY1FbWx+NwfmpvtTg==",
+      "dev": true,
+      "license": "MIT",
+      "bin": {
+        "acorn": "bin/acorn"
+      },
+      "engines": {
+        "node": ">=0.4.0"
+      }
+    },
+    "node_modules/acorn-walk": {
+      "version": "8.3.4",
+      "resolved": "https://registry.npmjs.org/acorn-walk/-/acorn-walk-8.3.4.tgz",
+      "integrity": "sha512-ueEepnujpqee2o5aIYnvHU6C0A42MNdsIDeqy5BydrkuC5R1ZuUFnm27EeFJGoEHJQgn3uleRvmTXaJgfXbt4g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "acorn": "^8.11.0"
+      },
+      "engines": {
+        "node": ">=0.4.0"
+      }
+    },
+    "node_modules/arg": {
+      "version": "4.1.3",
+      "resolved": "https://registry.npmjs.org/arg/-/arg-4.1.3.tgz",
+      "integrity": "sha512-58S9QDqG0Xx27YwPSt9fJxivjYl432YCwfDMfZ+71RAqUrZef7LrKQZ3LHLOwCS4FLNBplP533Zx895SeOCHvA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/base64-js": {
+      "version": "1.5.1",
+      "resolved": "https://registry.npmjs.org/base64-js/-/base64-js-1.5.1.tgz",
+      "integrity": "sha512-AKpaYlHn8t4SVbOHCy+b5+KKgvR4vrsD8vbvrbiQJps7fKDTkjkDry6ji0rUJjC0kzbNePLwzxq8iypo41qeWA==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
+      "license": "MIT"
+    },
+    "node_modules/buffer": {
+      "version": "6.0.3",
+      "resolved": "https://registry.npmjs.org/buffer/-/buffer-6.0.3.tgz",
+      "integrity": "sha512-FTiCpNxtwiZZHEZbcbTIcZjERVICn9yq/pDFkTl95/AxzD1naBctN7YO68riM/gLSDY7sdrMby8hofADYuuqOA==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "base64-js": "^1.3.1",
+        "ieee754": "^1.2.1"
+      }
+    },
+    "node_modules/commander": {
+      "version": "11.1.0",
+      "resolved": "https://registry.npmjs.org/commander/-/commander-11.1.0.tgz",
+      "integrity": "sha512-yPVavfyCcRhmorC7rWlkHn15b4wDVgVmBA7kV4QVBsF7kv/9TKJAbAXVTxvTnwP8HHKjRCJDClKbciiYS7p0DQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=16"
+      }
+    },
+    "node_modules/create-require": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/create-require/-/create-require-1.1.1.tgz",
+      "integrity": "sha512-dcKFX3jn0MpIaXjisoRvexIJVEKzaq7z2rZKxf+MSr9TkdmHmsU4m2lcLojrj/FHl8mk5VxMmYA+ftRkP/3oKQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/csstype": {
+      "version": "3.1.3",
+      "resolved": "https://registry.npmjs.org/csstype/-/csstype-3.1.3.tgz",
+      "integrity": "sha512-M1uQkMl8rQK/szD0LNhtqxIPLpimGm8sOBwU7lLnCpSbTyY3yeU1Vc7l4KT5zT4s/yOxHH5O7tIuuLOCnLADRw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/diff": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/diff/-/diff-4.0.2.tgz",
+      "integrity": "sha512-58lmxKSA4BNyLz+HHMUzlOEpg09FV+ev6ZMe3vJihgdxzgcwZ8VoEEPmALCZG9LmqfVoNMMKpttIYTVG6uDY7A==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "engines": {
+        "node": ">=0.3.1"
+      }
+    },
+    "node_modules/ieee754": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/ieee754/-/ieee754-1.2.1.tgz",
+      "integrity": "sha512-dcyqhDvX1C46lXZcVqCpK+FtMRQVdIMN6/Df5js2zouUsqG7I6sFxitIC+7KYK29KdXOLHdu9zL4sFnoVQnqaA==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
+      "license": "BSD-3-Clause"
+    },
+    "node_modules/js-tokens": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-4.0.0.tgz",
+      "integrity": "sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/loose-envify": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/loose-envify/-/loose-envify-1.4.0.tgz",
+      "integrity": "sha512-lyuxPGr/Wfhrlem2CL/UcnUc1zcqKAImBDzukY7Y5F/yQiNdko6+fRLevlw1HgMySw7f611UIY408EtxRSoK3Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "js-tokens": "^3.0.0 || ^4.0.0"
+      },
+      "bin": {
+        "loose-envify": "cli.js"
+      }
+    },
+    "node_modules/make-error": {
+      "version": "1.3.6",
+      "resolved": "https://registry.npmjs.org/make-error/-/make-error-1.3.6.tgz",
+      "integrity": "sha512-s8UhlNe7vPKomQhC1qFelMokr/Sc3AgNbso3n74mVPA5LTZwkB9NlXf4XPamLxJE8h0gh73rM94xvwRT2CVInw==",
+      "dev": true,
+      "license": "ISC"
+    },
+    "node_modules/neo4j-driver": {
+      "version": "5.28.1",
+      "resolved": "https://registry.npmjs.org/neo4j-driver/-/neo4j-driver-5.28.1.tgz",
+      "integrity": "sha512-jbyBwyM0a3RLGcP43q3hIxPUPxA+1bE04RovOKdNAS42EtBMVCKcPSeOvWiHxgXp1ZFd0a8XqK+7LtguInOLUg==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "neo4j-driver-bolt-connection": "5.28.1",
+        "neo4j-driver-core": "5.28.1",
+        "rxjs": "^7.8.1"
+      }
+    },
+    "node_modules/neo4j-driver-bolt-connection": {
+      "version": "5.28.1",
+      "resolved": "https://registry.npmjs.org/neo4j-driver-bolt-connection/-/neo4j-driver-bolt-connection-5.28.1.tgz",
+      "integrity": "sha512-nY8GBhjOW7J0rDtpiyJn6kFdk2OiNVZZhZrO8//mwNXnf5VQJ6HqZQTDthH/9pEaX0Jvbastz1xU7ZL8xzqY0w==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "buffer": "^6.0.3",
+        "neo4j-driver-core": "5.28.1",
+        "string_decoder": "^1.3.0"
+      }
+    },
+    "node_modules/neo4j-driver-core": {
+      "version": "5.28.1",
+      "resolved": "https://registry.npmjs.org/neo4j-driver-core/-/neo4j-driver-core-5.28.1.tgz",
+      "integrity": "sha512-14vN8TlxC0JvJYfjWic5PwjsZ38loQLOKFTXwk4fWLTbCk6VhrhubB2Jsy9Rz+gM6PtTor4+6ClBEFDp1q/c8g==",
+      "license": "Apache-2.0"
+    },
+    "node_modules/react": {
+      "version": "18.3.1",
+      "resolved": "https://registry.npmjs.org/react/-/react-18.3.1.tgz",
+      "integrity": "sha512-wS+hAgJShR0KhEvPJArfuPVN1+Hz1t0Y6n5jLrGQbkb4urgPE/0Rve+1kMB1v/oWgHgm4WIcV+i7F2pTVj+2iQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "loose-envify": "^1.1.0"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/rxjs": {
+      "version": "7.8.2",
+      "resolved": "https://registry.npmjs.org/rxjs/-/rxjs-7.8.2.tgz",
+      "integrity": "sha512-dhKf903U/PQZY6boNNtAGdWbG85WAbjT/1xYoZIC7FAY0yWapOBQVsVrDl58W86//e1VpMNBtRV4MaXfdMySFA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "tslib": "^2.1.0"
+      }
+    },
+    "node_modules/safe-buffer": {
+      "version": "5.2.1",
+      "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.2.1.tgz",
+      "integrity": "sha512-rp3So07KcdmmKbGvgaNxQSJr7bGVSVk5S9Eq1F+ppbRo70+YeaDxkw5Dd8NPN+GD6bjnYm2VuPuCXmpuYvmCXQ==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
+      "license": "MIT"
+    },
+    "node_modules/string_decoder": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.3.0.tgz",
+      "integrity": "sha512-hkRX8U1WjJFd8LsDJ2yQ/wWWxaopEsABU1XfkM8A+j0+85JAGppt16cr1Whg6KIbb4okU6Mql6BOj+uup/wKeA==",
+      "license": "MIT",
+      "dependencies": {
+        "safe-buffer": "~5.2.0"
+      }
+    },
+    "node_modules/ts-node": {
+      "version": "10.9.2",
+      "resolved": "https://registry.npmjs.org/ts-node/-/ts-node-10.9.2.tgz",
+      "integrity": "sha512-f0FFpIdcHgn8zcPSbf1dRevwt047YMnaiJM3u2w2RewrB+fob/zePZcrOyQoLMMO7aBIddLcQIEK5dYjkLnGrQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@cspotcode/source-map-support": "^0.8.0",
+        "@tsconfig/node10": "^1.0.7",
+        "@tsconfig/node12": "^1.0.7",
+        "@tsconfig/node14": "^1.0.0",
+        "@tsconfig/node16": "^1.0.2",
+        "acorn": "^8.4.1",
+        "acorn-walk": "^8.1.1",
+        "arg": "^4.1.0",
+        "create-require": "^1.1.0",
+        "diff": "^4.0.1",
+        "make-error": "^1.1.1",
+        "v8-compile-cache-lib": "^3.0.1",
+        "yn": "3.1.1"
+      },
+      "bin": {
+        "ts-node": "dist/bin.js",
+        "ts-node-cwd": "dist/bin-cwd.js",
+        "ts-node-esm": "dist/bin-esm.js",
+        "ts-node-script": "dist/bin-script.js",
+        "ts-node-transpile-only": "dist/bin-transpile.js",
+        "ts-script": "dist/bin-script-deprecated.js"
+      },
+      "peerDependencies": {
+        "@swc/core": ">=1.2.50",
+        "@swc/wasm": ">=1.2.50",
+        "@types/node": "*",
+        "typescript": ">=2.7"
+      },
+      "peerDependenciesMeta": {
+        "@swc/core": {
+          "optional": true
+        },
+        "@swc/wasm": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/tslib": {
+      "version": "2.8.1",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
+      "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
+      "license": "0BSD"
+    },
+    "node_modules/typescript": {
+      "version": "5.8.3",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.8.3.tgz",
+      "integrity": "sha512-p1diW6TqL9L07nNxvRMM7hMMw4c5XOo/1ibL4aAIGmSAt9slTE1Xgw5KWuof2uTOvCg9BY7ZRi+GaF+7sfgPeQ==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "bin": {
+        "tsc": "bin/tsc",
+        "tsserver": "bin/tsserver"
+      },
+      "engines": {
+        "node": ">=14.17"
+      }
+    },
+    "node_modules/undici-types": {
+      "version": "6.21.0",
+      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-6.21.0.tgz",
+      "integrity": "sha512-iwDZqg0QAGrg9Rav5H4n0M64c3mkR59cJ6wQp+7C4nI0gsmExaedaYLNO44eT4AtBBwjbTiGPMlt2Md0T9H9JQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/v8-compile-cache-lib": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/v8-compile-cache-lib/-/v8-compile-cache-lib-3.0.1.tgz",
+      "integrity": "sha512-wa7YjyUGfNZngI/vtK0UHAN+lgDCxBPCylVXGp0zu59Fz5aiGtNXaq3DhIov063MorB+VfufLh3JlF2KdTK3xg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/yn": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/yn/-/yn-3.1.1.tgz",
+      "integrity": "sha512-Ux4ygGWsu2c7isFWe8Yu1YluJmqVhxqK2cLXNQA5AcC3QfbGNpM7fu0Y8b/z16pXLnFxZYvWhd3fhBY9DLmC6Q==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
+    }
+  }
+}

--- a/package.json
+++ b/package.json
@@ -1,0 +1,20 @@
+{
+  "name": "ai-chat-reader",
+  "version": "1.0.0",
+  "type": "module",
+  "scripts": {
+    "start": "node bin/chat-reader.js",
+    "build": "tsc"
+  },
+  "dependencies": {
+    "commander": "^11.0.0",
+    "neo4j-driver": "^5.19.0"
+  },
+  "devDependencies": {
+    "typescript": "^5.4.0",
+    "ts-node": "^10.9.0",
+    "@types/node": "^20.9.0",
+    "react": "^18.2.0",
+    "@types/react": "^18.2.0"
+  }
+}

--- a/requirements.txt
+++ b/requirements.txt
@@ -7,3 +7,5 @@ pdfkit
 python-docx>=0.8.10
 reportlab>=3.6.0
 requests>=2.0.0
+ollama>=0.1.6
+lmstudio>=0.0.5

--- a/scripts/extract_concepts.py
+++ b/scripts/extract_concepts.py
@@ -1,0 +1,51 @@
+#!/usr/bin/env python3
+import json
+import sys
+import argparse
+
+try:
+    import ollama
+except ImportError:
+    ollama = None
+
+try:
+    import lmstudio
+except ImportError:
+    lmstudio = None
+
+PROMPT_TEMPLATE = (
+    "You are an information extraction agent. "
+    "Given the following text, identify the main concepts as a list of strings "
+    "and any directed relationships between them as triples [source, relation, target]. "
+    "Respond in JSON with keys 'concepts' and 'relations'.\nText:\n{text}"
+)
+
+
+def run_model(text: str, model: str):
+    if ollama:
+        response = ollama.chat(model=model, messages=[{"role": "user", "content": PROMPT_TEMPLATE.format(text=text)}])
+        return response["message"]["content"]
+    elif lmstudio:
+        client = lmstudio.Client()
+        result = client.prompt(model, PROMPT_TEMPLATE.format(text=text))
+        return result["choices"][0]["text"]
+    else:
+        raise RuntimeError("No LLM backend available. Install ollama or lmstudio.")
+
+
+def main():
+    parser = argparse.ArgumentParser(description="Extract concepts using a local LLM")
+    parser.add_argument("--model", default="deepseek-r1_0528")
+    parser.add_argument("text")
+    args = parser.parse_args()
+
+    raw = run_model(args.text, args.model)
+    try:
+        data = json.loads(raw)
+    except json.JSONDecodeError:
+        data = {"concepts": [], "relations": []}
+    print(json.dumps(data))
+
+
+if __name__ == "__main__":
+    main()

--- a/src/components/Toolbar.tsx
+++ b/src/components/Toolbar.tsx
@@ -1,0 +1,21 @@
+import React from 'react';
+
+export interface ToolbarProps {
+  importHkg: boolean;
+  onToggleImport: (val: boolean) => void;
+}
+
+export const Toolbar: React.FC<ToolbarProps> = ({ importHkg, onToggleImport }) => {
+  return (
+    <div className="toolbar">
+      <label>
+        <input
+          type="checkbox"
+          checked={importHkg}
+          onChange={e => onToggleImport(e.target.checked)}
+        />
+        Import to hKG
+      </label>
+    </div>
+  );
+};

--- a/src/generator.ts
+++ b/src/generator.ts
@@ -1,0 +1,46 @@
+import fs from 'fs';
+import path from 'path';
+import { extractConcepts } from './llm/deepseekClient';
+import { importToHkg, ThreadedMessage } from './hkgImporter';
+
+export interface GeneratorOptions {
+  inputPath: string;
+  importHkg?: boolean;
+  llmModel?: string;
+}
+
+interface RawMessage {
+  id: string;
+  text: string;
+  timestamp: number;
+  role: string;
+}
+
+function threadMessages(data: RawMessage[]): ThreadedMessage[] {
+  // In this simple scaffold we assume messages are already threaded
+  return data.map((m) => ({
+    uuid: m.id,
+    text: m.text,
+    timestamp: m.timestamp
+  }));
+}
+
+export async function generate(opts: GeneratorOptions) {
+  const raw = JSON.parse(fs.readFileSync(opts.inputPath, 'utf8')) as RawMessage[];
+  const messages = threadMessages(raw);
+
+  for (const msg of messages) {
+    const { concepts, relations } = await extractConcepts(msg.text, opts.llmModel);
+    msg.concepts = concepts;
+    msg.relations = relations;
+  }
+
+  if (opts.importHkg) {
+    await importToHkg(messages);
+  }
+
+  // HTML generation would happen here using existing templates
+  const outDir = path.join(path.dirname(opts.inputPath), 'html');
+  fs.mkdirSync(outDir, { recursive: true });
+  fs.writeFileSync(path.join(outDir, 'index.html'), '<html><body>Placeholder</body></html>');
+}

--- a/src/hkgImporter.ts
+++ b/src/hkgImporter.ts
@@ -1,0 +1,92 @@
+import fs from 'fs';
+import neo4j from 'neo4j-driver';
+import { extractConcepts } from './llm/deepseekClient';
+
+export interface ThreadedMessage {
+  uuid: string;
+  text: string;
+  timestamp: number;
+  concepts?: string[];
+  relations?: [string, string, string][];
+}
+
+/**
+ * Import threaded chat messages into the hKG Neo4j graph.
+ * Only messages newer than the stored `lastImportedTs` will be processed.
+ * A `hkg-delta.json` file is written with the processed messages for later
+ * ingestion into Qdrant for embeddings.
+ */
+export async function importToHkg(messages: ThreadedMessage[]) {
+  const driver = neo4j.driver(
+    process.env.NEO4J_URI || 'bolt://localhost:7687',
+    neo4j.auth.basic(
+      process.env.NEO4J_USER || 'neo4j',
+      process.env.NEO4J_PASSWORD || 'neo4j'
+    )
+  );
+  const session = driver.session();
+
+  // Load last imported timestamp from a Meta node
+  const metaRes = await session.run(
+    'MERGE (m:Meta {id: 1}) ON CREATE SET m.lastImportedTs = 0 RETURN m.lastImportedTs AS ts'
+  );
+  let lastImported = metaRes.records[0].get('ts') as number;
+
+  const delta: any[] = [];
+
+  for (const msg of messages) {
+    if (msg.timestamp <= lastImported) continue;
+
+    // Ensure concepts/relations are populated
+    if (!msg.concepts || !msg.relations) {
+      const { concepts, relations } = await extractConcepts(msg.text);
+      msg.concepts = concepts;
+      msg.relations = relations;
+    }
+
+    delta.push({
+      uuid: msg.uuid,
+      text: msg.text,
+      timestamp: msg.timestamp,
+      concepts: msg.concepts,
+      relations: msg.relations
+    });
+
+    // Scaffolding cypher statements
+    await session.run(
+      'MERGE (c:ChatMessage {uuid: $uuid}) SET c.text = $text, c.timestamp = $timestamp',
+      { uuid: msg.uuid, text: msg.text, timestamp: msg.timestamp }
+    );
+
+    for (const concept of msg.concepts || []) {
+      await session.run(
+        'MERGE (k:Concept {name: $name})',
+        { name: concept }
+      );
+      await session.run(
+        'MATCH (c:ChatMessage {uuid: $uuid}), (k:Concept {name: $name}) MERGE (c)-[:MENTIONS]->(k)',
+        { uuid: msg.uuid, name: concept }
+      );
+    }
+
+    for (const [a, rel, b] of msg.relations || []) {
+      await session.run(
+        'MERGE (ka:Concept {name: $a}) MERGE (kb:Concept {name: $b}) MERGE (ka)-[:RELATES {type: $rel}]->(kb)',
+        { a, b, rel }
+      );
+    }
+  }
+
+  if (delta.length) {
+    const newest = Math.max(...delta.map(d => d.timestamp));
+    await session.run(
+      'MERGE (m:Meta {id: 1}) SET m.lastImportedTs = $ts',
+      { ts: newest }
+    );
+  }
+
+  await session.close();
+  await driver.close();
+
+  fs.writeFileSync('hkg-delta.json', JSON.stringify(delta, null, 2));
+}

--- a/src/llm/deepseekClient.ts
+++ b/src/llm/deepseekClient.ts
@@ -1,0 +1,43 @@
+import { spawn } from 'child_process';
+import path from 'path';
+
+export interface ExtractResult {
+  concepts: string[];
+  relations: [string, string, string][];
+}
+
+/**
+ * Extract high-level concepts and relations from a text chunk using a local LLM.
+ * Defaults to the `deepseek-r1_0528` model but can be overridden via the
+ * `model` parameter or `LLM_MODEL` environment variable.
+ */
+export async function extractConcepts(text: string, model?: string): Promise<ExtractResult> {
+  const selectedModel = model || process.env.LLM_MODEL || 'deepseek-r1_0528';
+
+  const script = path.join(__dirname, '../../scripts/extract_concepts.py');
+
+  return new Promise((resolve, reject) => {
+    const proc = spawn('python3', [script, '--model', selectedModel, text]);
+    let stdout = '';
+    let stderr = '';
+
+    proc.stdout.on('data', (d) => (stdout += d.toString()));
+    proc.stderr.on('data', (d) => (stderr += d.toString()));
+
+    proc.on('close', () => {
+      if (stderr.trim()) {
+        reject(new Error(stderr.trim()));
+        return;
+      }
+      try {
+        const parsed = JSON.parse(stdout);
+        resolve({
+          concepts: parsed.concepts || [],
+          relations: parsed.relations || []
+        });
+      } catch {
+        resolve({ concepts: [], relations: [] });
+      }
+    });
+  });
+}

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,0 +1,14 @@
+{
+  "compilerOptions": {
+    "target": "es2020",
+    "module": "es2020",
+    "moduleResolution": "node",
+    "outDir": "dist",
+    "esModuleInterop": true,
+    "strict": true,
+    "skipLibCheck": true,
+    "jsx": "react"
+  },
+  "include": ["src/**/*.ts", "src/**/*.tsx"],
+  "exclude": ["node_modules"]
+}


### PR DESCRIPTION
## Summary
- scaffold Python script using ollama/lmstudio for concept extraction
- call script from the Node deepseek client
- include timestamp in hkg delta output
- record architecture snapshot and checklist
- declare Python dependencies for the new script

## Testing
- `npm install`
- `npx tsc --noEmit`


------
https://chatgpt.com/codex/tasks/task_e_68660522157c8323bdef0ad48d9c7f71