### PR TITLE
Fix GNOME desktop launch

### DIFF
--- a/docs/architecture/architecture-20250709-gnome-fix-final.md
+++ b/docs/architecture/architecture-20250709-gnome-fix-final.md
@@ -1,0 +1,27 @@
+# Architecture Snapshot - 2025-07-09 (After GNOME menu fix)
+
+```mermaid
+graph TD
+    A[src/main.js] --> B(MainWindow)
+    B --> C(HeaderBar)
+    B --> D(ConfigView)
+    B --> E(LogView)
+    D --> F(SettingsModel)
+    D --> G(FileManager)
+    D --> H(ProcessManager)
+    H --> I(LogView)
+    H --> J(NotificationManager)
+    K[scripts/build_packages.sh] --> L(chat-archive-converter.deb)
+    L --> M[Desktop Entry]
+    L --> Z[chat-archive-converter]
+    Z --> A
+    Z --> U(chat-archive-converter-cli)
+    U --> V[scripts/convert_to_html.py]
+    N[bin/chat-reader.js] --> O(generator.ts)
+    O --> P(deepseekClient.ts)
+    P --> X[scripts/extract_concepts.py]
+    O --> Q(hkgImporter.ts)
+    Q --> R((Neo4j))
+    Q --> S[hkg-delta.json]
+    S ..> T((Qdrant))
+```

--- a/docs/architecture/architecture-20250709-gnome-fix-initial.md
+++ b/docs/architecture/architecture-20250709-gnome-fix-initial.md
@@ -1,0 +1,23 @@
+# Architecture Snapshot - 2025-07-09 (Before GNOME menu fix)
+
+```mermaid
+graph TD
+    A[src/main.js] --> B(MainWindow)
+    B --> C(HeaderBar)
+    B --> D(ConfigView)
+    B --> E(LogView)
+    D --> F(SettingsModel)
+    D --> G(FileManager)
+    D --> H(ProcessManager)
+    H --> I(LogView)
+    H --> J(NotificationManager)
+    K[scripts/build_packages.sh] --> L(chat-archive-converter.deb)
+    L --> M[Desktop Entry]
+    N[bin/chat-reader.js] --> O(generator.ts)
+    O --> P(deepseekClient.ts)
+    P --> X[scripts/extract_concepts.py]
+    O --> Q(hkgImporter.ts)
+    Q --> R((Neo4j))
+    Q --> S[hkg-delta.json]
+    S ..> T((Qdrant))
+```

--- a/docs/checklists/checklist-20250709-gnome-menu.md
+++ b/docs/checklists/checklist-20250709-gnome-menu.md
@@ -1,0 +1,15 @@
+# Session Checklist - 2025-07-09 GNOME Menu Fix
+
+**UUID:** 8c4685b0-0de2-4ae8-9404-3e4ec0f69621
+**Created:** 2025-07-09
+**Status:** Complete
+
+## Changes
+- [x] Capture architecture snapshot before changes
+- [x] Update `scripts/build_packages.sh` to install GUI wrapper and rename CLI binary
+- [x] Create wrapper script `chat-archive-converter` launching GNOME GUI (src/main.js)
+- [x] Copy `src/` directory into packaging directories
+- [x] Update desktop entry Exec to use wrapper script
+- [/] Build packages via `scripts/build_packages.sh`
+- [x] Update architecture documentation after changes
+- [x] Record final checklist


### PR DESCRIPTION
## Summary
- add checklist for GNOME menu fix and capture architecture before change
- package GUI by copying src and adding a wrapper script
- output CLI as `chat-archive-converter-cli`
- update architecture diagram after fix

## Testing
- `npm run build` *(fails: missing dependencies)*
- `python3 -m py_compile scripts/convert_to_html.py`
- `bash scripts/build_packages.sh` *(fails: pyinstaller not found)*

------
https://chatgpt.com/codex/tasks/task_e_6869ba93ee488323a2c5be16e835a41d