### PR TITLE
Fix GNOME launcher wrapper path regression

### DIFF
--- a/docs/architecture/architecture-20250926-gnome-launcher-final.md
+++ b/docs/architecture/architecture-20250926-gnome-launcher-final.md
@@ -1,0 +1,32 @@
+# Architecture Plan - 2025-09-26 (GNOME Launcher Regression) - Final
+
+**Project UUIDv8:** 8f0f72f4-7b61-8e4d-bcb3-8f7a821dc9e5
+
+## Updated Flow Summary
+- `scripts/build_packages.sh` now writes the GNOME wrapper to execute `gjs "$DIR/src/main.js"`, matching the packaged directory structure where `main.js` lives under `src/`.
+- AppDir and DEB layouts continue to stage GUI assets under `/usr/share/chat-archive-converter/src`, while the CLI binary remains at `/usr/bin/chat-archive-converter-cli`.
+- GNOME desktop entry still launches the wrapper (`Exec=chat-archive-converter`), which `cd`s into `/usr/share/chat-archive-converter/` ensuring `imports.searchPath` resolves bundled widgets/utilities.
+
+## Adjusted AST Highlights
+```text
+scripts/build_packages.sh
+  ├─ Wrapper script cat <<'EOF'
+  │    #!/bin/bash
+  │    DIR="/usr/share/chat-archive-converter"
+  │    cd "$DIR"
+  │    exec gjs "$DIR/src/main.js" "$@"
+  ├─ Desktop entry unchanged (Exec=chat-archive-converter)
+  └─ DEB/AppImage stages rely on same wrapper script asset
+```
+
+## Mermaid Flow
+```mermaid
+flowchart TD
+    A[scripts/build_packages.sh] --> B[/usr/bin/chat-archive-converter]
+    B -->|cd| C[/usr/share/chat-archive-converter]
+    B -->|gjs| D[src/main.js]
+    D --> E[MainWindow]
+```
+
+## Knowledge Graph Sync
+- Final topology with corrected wrapper path logged for UUIDv8 `8f0f72f4-7b61-8e4d-bcb3-8f7a821dc9e5`.

--- a/docs/architecture/architecture-20250926-gnome-launcher-initial.md
+++ b/docs/architecture/architecture-20250926-gnome-launcher-initial.md
@@ -1,0 +1,80 @@
+# Architecture Plan - 2025-09-26 (GNOME Launcher Regression) - Initial
+
+**Project UUIDv8:** 8f0f72f4-7b61-8e4d-bcb3-8f7a821dc9e5
+
+## Context Snapshot
+- `src/main.js` bootstraps the GJS/Libadwaita application, extending `Adw.Application` and presenting `MainWindow`.
+- `src/widgets/MainWindow.js` assembles the primary window, composing `HeaderBar`, `ConfigView`, and `LogView`, and delegating process execution to `ProcessManager`.
+- `src/utils/ProcessManager.js` wraps `Gio.Subprocess` to run the Python converter with async stdout/stderr logging.
+- `scripts/build_packages.sh` orchestrates PyInstaller CLI packaging, AppImage/AppDir layout, GNOME wrapper creation, desktop entry generation, and DEB assembly.
+
+## Abstract AST Focus (Key Modules)
+```text
+scripts/build_packages.sh
+  ├─ pyinstaller invocation → dist/chat-archive-converter-cli
+  ├─ APPDIR staging
+  │   ├─ install CLI binary → usr/bin/chat-archive-converter-cli
+  │   ├─ wrapper script cat <<'EOF' (gjs "$DIR/main.js")
+  │   ├─ copy GUI sources → usr/share/chat-archive-converter/src
+  │   ├─ craft desktop entry Exec=chat-archive-converter
+  │   └─ generate placeholder icon
+  ├─ AppImage build via appimagetool
+  └─ DEB staging mirrors AppDir layout (wrapper + CLI + src/)
+
+src/main.js
+  ├─ shebang /usr/bin/gjs
+  ├─ push current_dir + '/src' into imports.searchPath
+  ├─ define Application extends Adw.Application
+  │   └─ _onActivate → instantiate MainWindow
+  └─ Adw.init(); application.run(ARGV)
+
+src/widgets/MainWindow.js
+  ├─ registerClass MainWindow extends Adw.ApplicationWindow
+  │   ├─ configure window title/size
+  │   ├─ compose HeaderBar / ConfigView / LogView
+  │   └─ connect 'execute-conversion' → ProcessManager.execute_script()
+  └─ callback logs output and posts notifications
+```
+
+## Identified Regression
+- Wrapper script written by `scripts/build_packages.sh` executes `gjs "$DIR/main.js"`, but packaging copies GUI files under `$DIR/src/`, leaving `$DIR/main.js` absent → GNOME launcher fails silently because the entry script cannot be found.
+
+## Proposed Remediation
+1. Update wrapper generation in `scripts/build_packages.sh` to execute `gjs "$DIR/src/main.js"` to match packaged layout.
+2. Ensure `imports.searchPath` in `src/main.js` continues to resolve nested modules when executed from AppDir/DEB (`cd "$DIR"` already set by wrapper).
+3. Run smoke test for packaging script (syntax validation / shellcheck) if feasible; otherwise, document manual testing requirement.
+4. Capture post-fix architecture snapshot (final) and update checklist/test notes.
+
+## Diagrams
+```mermaid
+flowchart TD
+    subgraph Packaging
+        A[scripts/build_packages.sh]
+        A --> B[AppDir Wrapper]
+        B --> C{Exec Path}
+    end
+    subgraph GUI
+        D[src/main.js] --> E[MainWindow]
+        E --> F[ProcessManager]
+    end
+    C -->|gjs| D
+```
+
+```mermaid
+classDiagram
+    class Application {
+        +constructor()
+        +_onActivate()
+    }
+    class MainWindow {
+        +_init(args)
+    }
+    class ProcessManager {
+        +execute_script(script_path, args, on_stdout, on_stderr, on_exit)
+    }
+    Application --> MainWindow
+    MainWindow --> ProcessManager
+```
+
+## HKG Sync
+- Recorded planned remediation for UUIDv8 `8f0f72f4-7b61-8e4d-bcb3-8f7a821dc9e5` in hybrid knowledge graph (see checklist for task linkage).

--- a/docs/checklists/checklist-20250926-gnome-launcher.md
+++ b/docs/checklists/checklist-20250926-gnome-launcher.md
@@ -1,0 +1,17 @@
+# Session Checklist - 2025-09-26 GNOME Launcher Regression
+
+**UUIDv8:** 3e3297bc-17b4-81bb-8c03-c0d3924827d9
+**Created:** 2025-09-26T13:13Z
+**Status:** Complete
+
+## Planned Tasks
+- [x] Confirm packaging regression by inspecting `scripts/build_packages.sh` wrapper section and verifying target path for `main.js`.
+- [x] Modify wrapper creation in `scripts/build_packages.sh` to execute `gjs "$DIR/src/main.js"` (ensure both AppDir and DEB sections updated if duplicated).
+- [x] Ensure desktop entry and file layout remain consistent after wrapper change (no additional adjustments needed).
+- [x] Run `bash -n scripts/build_packages.sh` to syntax-check the packaging script (substitute with documentation if tool unavailable).
+- [x] Update or create final architecture snapshot reflecting corrected wrapper path.
+- [x] Document testing status in repository (README or checklist notes) if runtime verification via GNOME is not possible in CI environment.
+
+## Testing Targets
+- ✅ Smoke syntax check: `bash -n scripts/build_packages.sh`
+- ⚠️ Manual GNOME launcher click test on Ubuntu 22.04+ (deferred to downstream tester).

--- a/scripts/build_packages.sh
+++ b/scripts/build_packages.sh
@@ -13,7 +13,7 @@ cat > "$APPDIR/usr/bin/chat-archive-converter" <<'EOF'
 #!/bin/bash
 DIR="/usr/share/chat-archive-converter"
 cd "$DIR"
-exec gjs "$DIR/main.js" "$@"
+exec gjs "$DIR/src/main.js" "$@"
 EOF
 chmod +x "$APPDIR/usr/bin/chat-archive-converter"
 # Copy GUI source


### PR DESCRIPTION
## Summary
- point the GNOME wrapper script generated by `build_packages.sh` at `src/main.js` so the packaged launcher can find the entry point again
- record the investigation and resolution in the architecture and checklist docs for the GNOME launcher regression

## Testing
- bash -n scripts/build_packages.sh

------
https://chatgpt.com/codex/tasks/task_e_68d691339db48323a47ab8d5f1ca4dcd